### PR TITLE
AnnotationDesc value may not be a ClassDoc

### DIFF
--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/AnnotationParser.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/AnnotationParser.java
@@ -9,6 +9,7 @@ import com.sun.javadoc.AnnotationValue;
 import com.sun.javadoc.ClassDoc;
 import com.sun.javadoc.Parameter;
 import com.sun.javadoc.ProgramElementDoc;
+import com.sun.tools.javadoc.ParameterizedTypeImpl;
 import com.tenxerconsulting.swagger.doclet.DocletOptions;
 
 /**
@@ -89,8 +90,14 @@ public class AnnotationParser {
 	private ClassDoc getAnnotationClassDocValue(AnnotationDesc annotation, String key) {
 		for (AnnotationDesc.ElementValuePair evp : annotation.elementValues()) {
 			if (evp.element().name().equals(key)) {
-				ClassDoc val = (ClassDoc) evp.value().value();
-				return val;
+				Object val = evp.value().value();
+				if(val instanceof ClassDoc) {
+					return (ClassDoc) val;
+				}
+				if(val instanceof ParameterizedTypeImpl) {
+					ParameterizedTypeImpl pVal = (ParameterizedTypeImpl) val;
+					return pVal.asClassDoc();
+				}
 			}
 		}
 		return null;

--- a/swagger-doclet/src/test/java/com/tenxerconsulting/swagger/doclet/apidocs/JsonSubTypesGenericResourceTest.java
+++ b/swagger-doclet/src/test/java/com/tenxerconsulting/swagger/doclet/apidocs/JsonSubTypesGenericResourceTest.java
@@ -1,0 +1,40 @@
+package com.tenxerconsulting.swagger.doclet.apidocs;
+
+import com.sun.javadoc.RootDoc;
+import com.tenxerconsulting.swagger.doclet.DocletOptions;
+import com.tenxerconsulting.swagger.doclet.Recorder;
+import com.tenxerconsulting.swagger.doclet.model.ApiDeclaration;
+import com.tenxerconsulting.swagger.doclet.parser.JaxRsAnnotationParser;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.tenxerconsulting.swagger.doclet.apidocs.FixtureLoader.loadFixture;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("javadoc")
+public class JsonSubTypesGenericResourceTest {
+
+	private Recorder recorderMock;
+	private DocletOptions options;
+
+	@Before
+	public void setup() {
+		this.recorderMock = mock(Recorder.class);
+		this.options = new DocletOptions().setRecorder(this.recorderMock).setIncludeSwaggerUi(false);
+	}
+
+	@Test
+	public void testStart() throws IOException {
+		final RootDoc rootDoc = RootDocLoader.fromPath("src/test/resources", "fixtures.jsonsubtypesgeneric");
+		new JaxRsAnnotationParser(this.options, rootDoc).run();
+
+		final ApiDeclaration api = loadFixture("/fixtures/jsonsubtypesgeneric/jsonsubtypes.json", ApiDeclaration.class);
+		verify(this.recorderMock).record(any(File.class), eq(api));
+	}
+
+}

--- a/swagger-doclet/src/test/resources/fixtures/jsonsubtypesgeneric/Animal.java
+++ b/swagger-doclet/src/test/resources/fixtures/jsonsubtypesgeneric/Animal.java
@@ -1,0 +1,14 @@
+package fixtures.jsonsubtypesgeneric;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@SuppressWarnings("javadoc")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({ @Type(value = Cat1.class, name = "cat1"), @Type(value = Dog1.class, name = "dog1") })
+public abstract class Animal<T> {
+
+	public String name;
+
+}

--- a/swagger-doclet/src/test/resources/fixtures/jsonsubtypesgeneric/Cat1.java
+++ b/swagger-doclet/src/test/resources/fixtures/jsonsubtypesgeneric/Cat1.java
@@ -1,0 +1,8 @@
+package fixtures.jsonsubtypesgeneric;
+
+@SuppressWarnings("javadoc")
+public class Cat1<T> extends Animal<T> {
+
+	public String favoriteToy;
+
+}

--- a/swagger-doclet/src/test/resources/fixtures/jsonsubtypesgeneric/Dog1.java
+++ b/swagger-doclet/src/test/resources/fixtures/jsonsubtypesgeneric/Dog1.java
@@ -1,0 +1,9 @@
+package fixtures.jsonsubtypesgeneric;
+
+@SuppressWarnings("javadoc")
+public class Dog1<T> extends Animal<T> {
+
+	public String breed;
+	public String leashColor;
+
+}

--- a/swagger-doclet/src/test/resources/fixtures/jsonsubtypesgeneric/JsonSubTypesResource.java
+++ b/swagger-doclet/src/test/resources/fixtures/jsonsubtypesgeneric/JsonSubTypesResource.java
@@ -1,0 +1,20 @@
+package fixtures.jsonsubtypesgeneric;
+
+import java.util.Collection;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@SuppressWarnings("javadoc")
+@Path("/jsonSubTypesResource")
+public class JsonSubTypesResource {
+
+	@GET
+	@Path("/animal")
+	public Animal getAnimal() {
+		return null;
+	}
+
+}

--- a/swagger-doclet/src/test/resources/fixtures/jsonsubtypesgeneric/jsonsubtypes.json
+++ b/swagger-doclet/src/test/resources/fixtures/jsonsubtypesgeneric/jsonsubtypes.json
@@ -1,0 +1,53 @@
+{
+    "apiVersion": "0",
+    "swaggerVersion": "1.2",
+    "basePath": "http://localhost:8080",
+    "resourcePath": "/jsonSubTypesResource",
+    "apis": [
+        {
+            "path": "/jsonSubTypesResource/animal",
+            "operations": [
+            	{
+                    "method": "GET",
+                    "nickname": "getAnimal",
+                    "type": "Animal"
+                }
+            ]
+        }
+    ],
+    "models": {
+    	"Animal": {
+            "id": "Animal",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "required" : ["type"],
+            "subTypes" : ["Cat1", "Dog1"],
+            "discriminator" : "type"
+        },
+        "Cat1": {
+            "id": "Cat1",
+            "properties": {
+                "favoriteToy": {
+                    "type": "string"
+                }
+            }
+        },
+        "Dog1": {
+            "id": "Dog1",
+            "properties": {
+                "breed": {
+                    "type": "string"
+                },
+                "leashColor": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
If a subclass is generic, the element value is of type ParameterizedTypeImpl, not ClassDoc.
Detect and handle this case.
