### PR TITLE
fix handling of generic/Map response types

### DIFF
--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ApiMethodParser.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ApiMethodParser.java
@@ -176,7 +176,7 @@ public class ApiMethodParser {
 
 		// look for a custom return type, this is useful where we return a jaxrs Response in the method signature
 		// but typically return a different object in its entity (such as for a 201 created response)
-		String customReturnTypeName = ParserHelper.getInheritableTagValue(this.methodDoc, this.options.getResponseTypeTags(), this.options);
+		String customReturnTypeName = ParserHelper.responseTypeTagOf(this.methodDoc, this.options);
 		NameToType nameToType = readCustomReturnType(customReturnTypeName, viewClasses);
 		if (nameToType != null) {
 			returnTypeName = nameToType.returnTypeName;

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ClassDocCache.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ClassDocCache.java
@@ -57,4 +57,17 @@ public class ClassDocCache {
 		return null;
 	}
 
+	/**
+	 * This finds a class doc matching the given type name
+	 * @param type The type to find a matching class doc for
+	 * @return The class doc or null if none matched
+	 */
+	public ClassDoc findByName(String typeName) {
+		return this.typeNameToClass.get(typeName);
+	}
+
+	@Override
+	public String toString() {
+		return typeNameToClass.keySet().toString();
+	}
 }

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/JaxRsAnnotationParser.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/JaxRsAnnotationParser.java
@@ -162,13 +162,14 @@ public class JaxRsAnnotationParser {
 					for (MethodDoc method : currentClassDoc.methods()) {
 						// if the method has @Path but no Http method then its an entry point to a sub resource
 						if (!ParserHelper.resolveMethodPath(method, this.options).isEmpty() && HttpMethod.fromMethod(method) == null) {
-							ClassDoc subResourceClassDoc = classCache.findByType(method.returnType());
+							String responseTypeTag = ParserHelper.responseTypeTagOf(method, this.options);
+							ClassDoc subResourceClassDoc = responseTypeTag == null ? classCache.findByType(method.returnType()) : classCache.findByName(responseTypeTag);
 							if (subResourceClassDoc != null) {
 								if (this.options.isLogDebug()) {
 									System.out.println("Adding return type as sub resource class : " + subResourceClassDoc.name() + " for method "
 											+ method.name() + " of referencing class " + currentClassDoc.name());
 								}
-								subResourceClasses.put(method.returnType(), subResourceClassDoc);
+								subResourceClasses.put(subResourceClassDoc, subResourceClassDoc);
 							}
 						}
 					}

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
@@ -531,6 +531,19 @@ public class ParserHelper {
 	}
 
 	/**
+	 * This gets the FQN of a method response type from tags.
+	 * @param methodDoc The method
+	 * @param options The doclet options
+	 * @return The FQN of the response type tag or null if none found
+	 * @see com.tenxerconsulting.swagger.doclet.parser.ApiMethodParser.readCustomReturnType(String, ClassDoc[])
+	 */
+	public static String responseTypeTagOf(MethodDoc methodDoc, DocletOptions options) {
+		// looking for a custom return type, this is useful where we return a jaxrs Response in the method signature
+		// but typically return a different object in its entity (such as for a 201 created response)
+		return getInheritableTagValue(methodDoc, options.getResponseTypeTags(), options);
+	}
+
+	/**
 	 * This gets parameterized types of the given type substituting variable types if necessary
 	 * @param type The raw type such as Batch&lt;Item&gt; or Batch&lt;T, Y&gt;
 	 * @param varsToTypes A map of variable name to types

--- a/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
+++ b/swagger-doclet/src/main/java/com/tenxerconsulting/swagger/doclet/parser/ParserHelper.java
@@ -354,6 +354,10 @@ public class ParserHelper {
 			return new String[] { "array", null };
 		} else if (isArray(javaType)) {
 			return new String[] { "array", null };
+		} else if (isMap(javaType)) {
+			// Swagger Spec 1.2 has no support for further specifying dict key/value type
+			// (unlike additionalProperties in OAS 2, see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md)
+			return new String[] { "object", null };
 		} else if (javaType.equalsIgnoreCase("java.io.File")) {
 			// special handling of files, the datatype File is reserved for multipart
 			return new String[] { "JavaFile", null };


### PR DESCRIPTION
- allow `@responseType` tags to override return type in `JaxRsParser` like already done in `ApiMethodParser`
- translate `java.util.Map` types to `object` (OAS 1.2 offers no better way)